### PR TITLE
Fix reading nested data type inner columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ TODO
 // then generate strawboat file
 cargo run --example strawboat_write --release /tmp/input.str
 
-// read starwboat file
+// read strawboat file
 cargo run --example strawboat_read  --release /tmp/input.str
 
 // compare parquet reader

--- a/examples/strawboat_read.rs
+++ b/examples/strawboat_read.rs
@@ -8,7 +8,7 @@ use arrow::io::parquet::write::to_parquet_schema;
 
 use arrow::error::Result;
 
-use strawboat::read::reader::{infer_schema, read_meta, NativeReader};
+use strawboat::read::reader::{infer_schema, is_primitive, read_meta, NativeReader};
 use strawboat::ColumnMeta;
 
 /// Simplest way: read all record batches from the file. This can be used e.g. for random access.
@@ -53,9 +53,11 @@ fn main() -> Result<()> {
                 scratchs.push(scratch);
             }
 
+            let is_nested = is_primitive(field.data_type());
             let pa_reader = NativeReader::new(
                 page_readers,
                 field.clone(),
+                is_nested,
                 curr_leaves,
                 curr_metas,
                 scratchs,

--- a/examples/strawboat_read.rs
+++ b/examples/strawboat_read.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
                 scratchs.push(scratch);
             }
 
-            let is_nested = is_primitive(field.data_type());
+            let is_nested = !is_primitive(field.data_type());
             let pa_reader = NativeReader::new(
                 page_readers,
                 field.clone(),

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -60,7 +60,7 @@ impl<R: NativeReadBuf> NativeReader<R> {
 
     /// must call after has_next
     pub fn next_array(&mut self) -> Result<Box<dyn Array>> {
-        let result = if self.is_nested {
+        let result = if !self.is_nested {
             let page_meta = &self.column_metas[0].pages[self.current_page].clone();
 
             deserialize::read_simple(

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -13,7 +13,7 @@ use std::io::{Read, Seek, SeekFrom};
 
 use arrow::io::parquet::read::ColumnDescriptor;
 
-fn is_primitive(data_type: &DataType) -> bool {
+pub fn is_primitive(data_type: &DataType) -> bool {
     matches!(
         data_type.to_physical_type(),
         PhysicalType::Primitive(_)
@@ -31,6 +31,7 @@ fn is_primitive(data_type: &DataType) -> bool {
 pub struct NativeReader<R: NativeReadBuf> {
     page_readers: Vec<R>,
     field: Field,
+    is_nested: bool,
     leaves: Vec<ColumnDescriptor>,
     column_metas: Vec<ColumnMeta>,
     current_page: usize,
@@ -41,6 +42,7 @@ impl<R: NativeReadBuf> NativeReader<R> {
     pub fn new(
         page_readers: Vec<R>,
         field: Field,
+        is_nested: bool,
         leaves: Vec<ColumnDescriptor>,
         column_metas: Vec<ColumnMeta>,
         scratchs: Vec<Vec<u8>>,
@@ -48,6 +50,7 @@ impl<R: NativeReadBuf> NativeReader<R> {
         Self {
             page_readers,
             field,
+            is_nested,
             leaves,
             column_metas,
             current_page: 0,
@@ -57,7 +60,7 @@ impl<R: NativeReadBuf> NativeReader<R> {
 
     /// must call after has_next
     pub fn next_array(&mut self) -> Result<Box<dyn Array>> {
-        let result = if is_primitive(self.field.data_type()) {
+        let result = if self.is_nested {
             let page_meta = &self.column_metas[0].pages[self.current_page].clone();
 
             deserialize::read_simple(

--- a/src/write/writer.rs
+++ b/src/write/writer.rs
@@ -75,7 +75,7 @@ impl<W: Write> NativeWriter<W> {
     pub fn start(&mut self) -> Result<()> {
         if self.state != State::None {
             return Err(Error::OutOfSpec(
-                "The starwboat file can only be started once".to_string(),
+                "The strawboat file can only be started once".to_string(),
             ));
         }
         // write magic to header
@@ -91,12 +91,12 @@ impl<W: Write> NativeWriter<W> {
     pub fn write(&mut self, chunk: &Chunk<Box<dyn Array>>) -> Result<()> {
         if self.state == State::Written {
             return Err(Error::OutOfSpec(
-                "The starwboat file can only accept one RowGroup in a single file".to_string(),
+                "The strawboat file can only accept one RowGroup in a single file".to_string(),
             ));
         }
         if self.state != State::Started {
             return Err(Error::OutOfSpec(
-                "The starwboat file must be started before it can be written to. Call `start` before `write`".to_string(),
+                "The strawboat file must be started before it can be written to. Call `start` before `write`".to_string(),
             ));
         }
         assert_eq!(chunk.arrays().len(), self.schema.fields.len());
@@ -112,7 +112,7 @@ impl<W: Write> NativeWriter<W> {
     pub fn finish(&mut self) -> Result<()> {
         if self.state != State::Written {
             return Err(Error::OutOfSpec(
-                "The starwboat file must be written before it can be finished. Call `start` before `finish`".to_string(),
+                "The strawboat file must be written before it can be finished. Call `start` before `finish`".to_string(),
             ));
         }
         // write footer

--- a/tests/it/io.rs
+++ b/tests/it/io.rs
@@ -239,7 +239,7 @@ fn test_write_read(chunk: Chunk<Box<dyn Array>>, options: WriteOptions) {
             let scratch = Vec::new();
             scratchs.push(scratch);
         }
-        let is_nested = is_primitive(field.data_type());
+        let is_nested = !is_primitive(field.data_type());
         let mut reader = NativeReader::new(
             page_readers,
             field.clone(),

--- a/tests/it/io.rs
+++ b/tests/it/io.rs
@@ -12,7 +12,7 @@ use arrow::{
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::io::BufRead;
 use strawboat::{
-    read::reader::NativeReader,
+    read::reader::{is_primitive, NativeReader},
     write::{NativeWriter, WriteOptions},
     ColumnMeta, Compression,
 };
@@ -239,10 +239,11 @@ fn test_write_read(chunk: Chunk<Box<dyn Array>>, options: WriteOptions) {
             let scratch = Vec::new();
             scratchs.push(scratch);
         }
-
+        let is_nested = is_primitive(field.data_type());
         let mut reader = NativeReader::new(
             page_readers,
             field.clone(),
+            is_nested,
             curr_leaves,
             curr_metas,
             scratchs,


### PR DESCRIPTION
As primitive columns and nested columns have different storage data formats, reading an inner column of the nested data type need to know the column storage data format.