### PR TITLE
fix read multi-level nested list

### DIFF
--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
         assert!(!chunk.is_empty());
 
         println!("chunk len -> {:?}", chunk.len());
-        // println!("{}", print::write(&[chunk], &["names"]));
+        println!("chunk={chunk:?}");
     }
     println!("took: {} ms", start.elapsed().unwrap().as_millis());
 

--- a/src/read/array/list.rs
+++ b/src/read/array/list.rs
@@ -1,9 +1,10 @@
 use arrow::array::Array;
-use arrow::datatypes::Field;
+use arrow::datatypes::{DataType, Field};
 use arrow::error::Result;
 use arrow::io::parquet::read::{create_list, NestedState};
 
 use crate::read::deserialize::DynIter;
+use crate::read::reader::is_primitive_or_struct;
 
 /// An iterator adapter over [`DynIter`] assumed to be encoded as List arrays
 pub struct ListIterator<'a> {
@@ -28,9 +29,17 @@ impl<'a> ListIterator<'a> {
             Some(Err(err)) => return Some(Err(err)),
             None => return None,
         };
-        // pop the primitive nested
-        let _ = nested.nested.pop().unwrap();
-
+        match &self.field.data_type {
+            DataType::List(inner)
+            | DataType::LargeList(inner)
+            | DataType::FixedSizeList(inner, _) => {
+                if is_primitive_or_struct(&inner.data_type) {
+                    // pop the primitive nested
+                    let _ = nested.nested.pop().unwrap();
+                }
+            }
+            _ => unreachable!(),
+        }
         let array = create_list(self.field.data_type().clone(), &mut nested, values);
         Some(Ok((nested, array)))
     }

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -24,6 +24,22 @@ pub fn is_primitive(data_type: &DataType) -> bool {
     )
 }
 
+pub fn is_primitive_or_struct(data_type: &DataType) -> bool {
+    matches!(
+        data_type.to_physical_type(),
+        PhysicalType::Primitive(_)
+            | PhysicalType::Null
+            | PhysicalType::Boolean
+            | PhysicalType::Utf8
+            | PhysicalType::LargeUtf8
+            | PhysicalType::Binary
+            | PhysicalType::LargeBinary
+            | PhysicalType::FixedSizeBinary
+            | PhysicalType::Dictionary(_)
+            | PhysicalType::Struct
+    )
+}
+
 #[derive(Debug)]
 pub struct NativeReader<R: NativeReadBuf> {
     page_reader: R,


### PR DESCRIPTION
- fix read multi-level nested list.
- add test cases for all `Compression`s: `None`, `LZ4`, `ZSTD`, `SNAPPY`.
- add test cases for `list-list`, `list-map`, `list-struct`, and `struct-list`.

Closes #28