### PR TITLE
fix read nested nullable data types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lz4 = { version = "1.23.1" }
 zstd = { version = "0.11" }
 snap = { version = "1.1.0" }
 
-arrow = { package = "arrow2", git = "https://github.com/b41sh/arrow2", rev = "a13f96e", default-features = false, features = [
+arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "db87f71", default-features = false, features = [
 	"benchmarks",
 	"io_parquet",
 	"compute",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ lz4 = { version = "1.23.1" }
 zstd = { version = "0.11" }
 snap = { version = "1.1.0" }
 
-arrow = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "9749aee", default-features = false, features = [
+arrow = { package = "arrow2", git = "https://github.com/b41sh/arrow2", rev = "a13f96e", default-features = false, features = [
 	"benchmarks",
 	"io_parquet",
 	"compute",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-12-15"
+channel = "nightly-2023-03-10"
 components = ["rustfmt", "clippy", "rust-src", "miri"]

--- a/src/read/array/binary.rs
+++ b/src/read/array/binary.rs
@@ -146,13 +146,13 @@ where
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) = read_validity_nested(
+        let (mut nested, validity) = read_validity_nested(
             &mut reader,
             num_values as usize,
             &self.leaf,
             self.init.clone(),
         )?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let length = nested.nested.pop().unwrap().len();
         let offsets: Buffer<O> = read_buffer(&mut reader, 1 + length, &mut self.scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(&mut reader, last_offset, &mut self.scratch)?;
@@ -279,8 +279,8 @@ pub fn read_nested_binary<O: Offset, R: NativeReadBuf>(
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
         let num_values = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let (mut nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested.pop().unwrap().len();
         let offsets: Buffer<O> = read_buffer(reader, 1 + length, &mut scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(reader, last_offset, &mut scratch)?;

--- a/src/read/array/binary.rs
+++ b/src/read/array/binary.rs
@@ -145,10 +145,14 @@ where
         num_values: u64,
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
-        let length = num_values as usize;
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) =
-            read_validity_nested(&mut reader, length, &self.leaf, self.init.clone())?;
+        let (nested, validity) = read_validity_nested(
+            &mut reader,
+            num_values as usize,
+            &self.leaf,
+            self.init.clone(),
+        )?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let offsets: Buffer<O> = read_buffer(&mut reader, 1 + length, &mut self.scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(&mut reader, last_offset, &mut self.scratch)?;
@@ -274,9 +278,9 @@ pub fn read_nested_binary<O: Offset, R: NativeReadBuf>(
 
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
-        let length = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, length, &leaf, init.clone())?;
-
+        let num_values = page_meta.num_values as usize;
+        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let offsets: Buffer<O> = read_buffer(reader, 1 + length, &mut scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(reader, last_offset, &mut scratch)?;

--- a/src/read/array/boolean.rs
+++ b/src/read/array/boolean.rs
@@ -123,10 +123,14 @@ where
         num_values: u64,
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
-        let length = num_values as usize;
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) =
-            read_validity_nested(&mut reader, length, &self.leaf, self.init.clone())?;
+        let (nested, validity) = read_validity_nested(
+            &mut reader,
+            num_values as usize,
+            &self.leaf,
+            self.init.clone(),
+        )?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let mut bitmap_builder = MutableBitmap::with_capacity(length);
         read_bitmap(&mut reader, length, &mut self.scratch, &mut bitmap_builder)?;
         let values = std::mem::take(&mut bitmap_builder).into();
@@ -202,8 +206,9 @@ pub fn read_nested_boolean<R: NativeReadBuf>(
 
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
-        let length = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, length, &leaf, init.clone())?;
+        let num_values = page_meta.num_values as usize;
+        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let mut bitmap_builder = MutableBitmap::with_capacity(length);
         read_bitmap(reader, length, &mut scratch, &mut bitmap_builder)?;
         let values = std::mem::take(&mut bitmap_builder).into();

--- a/src/read/array/boolean.rs
+++ b/src/read/array/boolean.rs
@@ -124,13 +124,13 @@ where
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) = read_validity_nested(
+        let (mut nested, validity) = read_validity_nested(
             &mut reader,
             num_values as usize,
             &self.leaf,
             self.init.clone(),
         )?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let length = nested.nested.pop().unwrap().len();
         let mut bitmap_builder = MutableBitmap::with_capacity(length);
         read_bitmap(&mut reader, length, &mut self.scratch, &mut bitmap_builder)?;
         let values = std::mem::take(&mut bitmap_builder).into();
@@ -207,8 +207,8 @@ pub fn read_nested_boolean<R: NativeReadBuf>(
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
         let num_values = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let (mut nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested.pop().unwrap().len();
         let mut bitmap_builder = MutableBitmap::with_capacity(length);
         read_bitmap(reader, length, &mut scratch, &mut bitmap_builder)?;
         let values = std::mem::take(&mut bitmap_builder).into();

--- a/src/read/array/list.rs
+++ b/src/read/array/list.rs
@@ -1,10 +1,9 @@
 use arrow::array::Array;
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::Field;
 use arrow::error::Result;
 use arrow::io::parquet::read::{create_list, NestedState};
 
 use crate::read::deserialize::DynIter;
-use crate::read::reader::is_primitive_or_struct;
 
 /// An iterator adapter over [`DynIter`] assumed to be encoded as List arrays
 pub struct ListIterator<'a> {
@@ -29,17 +28,6 @@ impl<'a> ListIterator<'a> {
             Some(Err(err)) => return Some(Err(err)),
             None => return None,
         };
-        match &self.field.data_type {
-            DataType::List(inner)
-            | DataType::LargeList(inner)
-            | DataType::FixedSizeList(inner, _) => {
-                if is_primitive_or_struct(&inner.data_type) {
-                    // pop the primitive nested
-                    let _ = nested.nested.pop().unwrap();
-                }
-            }
-            _ => unreachable!(),
-        }
         let array = create_list(self.field.data_type().clone(), &mut nested, values);
         Some(Ok((nested, array)))
     }

--- a/src/read/array/map.rs
+++ b/src/read/array/map.rs
@@ -28,9 +28,6 @@ impl<'a> MapIterator<'a> {
             Some(Err(err)) => return Some(Err(err)),
             None => return None,
         };
-        // pop the primitive nested
-        let _ = nested.nested.pop().unwrap();
-
         let array = create_map(self.field.data_type().clone(), &mut nested, values);
         Some(Ok((nested, array)))
     }

--- a/src/read/array/primitive.rs
+++ b/src/read/array/primitive.rs
@@ -140,13 +140,13 @@ where
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) = read_validity_nested(
+        let (mut nested, validity) = read_validity_nested(
             &mut reader,
             num_values as usize,
             &self.leaf,
             self.init.clone(),
         )?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let length = nested.nested.pop().unwrap().len();
         let values = read_buffer(&mut reader, length, &mut self.scratch)?;
 
         let mut buffer = reader.into_inner().into_inner();
@@ -225,8 +225,8 @@ pub fn read_nested_primitive<T: NativeType, R: NativeReadBuf>(
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
         let num_values = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let (mut nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested.pop().unwrap().len();
         let values = read_buffer(reader, length, &mut scratch)?;
 
         let array = PrimitiveArray::<T>::try_new(data_type.clone(), values, validity)?;

--- a/src/read/array/primitive.rs
+++ b/src/read/array/primitive.rs
@@ -139,10 +139,14 @@ where
         num_values: u64,
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
-        let length = num_values as usize;
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) =
-            read_validity_nested(&mut reader, length, &self.leaf, self.init.clone())?;
+        let (nested, validity) = read_validity_nested(
+            &mut reader,
+            num_values as usize,
+            &self.leaf,
+            self.init.clone(),
+        )?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let values = read_buffer(&mut reader, length, &mut self.scratch)?;
 
         let mut buffer = reader.into_inner().into_inner();
@@ -220,8 +224,9 @@ pub fn read_nested_primitive<T: NativeType, R: NativeReadBuf>(
     let mut scratch = vec![];
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
-        let length = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, length, &leaf, init.clone())?;
+        let num_values = page_meta.num_values as usize;
+        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let values = read_buffer(reader, length, &mut scratch)?;
 
         let array = PrimitiveArray::<T>::try_new(data_type.clone(), values, validity)?;

--- a/src/read/array/utf8.rs
+++ b/src/read/array/utf8.rs
@@ -145,10 +145,14 @@ where
         num_values: u64,
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
-        let length = num_values as usize;
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) =
-            read_validity_nested(&mut reader, length, &self.leaf, self.init.clone())?;
+        let (nested, validity) = read_validity_nested(
+            &mut reader,
+            num_values as usize,
+            &self.leaf,
+            self.init.clone(),
+        )?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let offsets: Buffer<O> = read_buffer(&mut reader, 1 + length, &mut self.scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(&mut reader, last_offset, &mut self.scratch)?;
@@ -274,9 +278,9 @@ pub fn read_nested_utf8<O: Offset, R: NativeReadBuf>(
 
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
-        let length = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, length, &leaf, init.clone())?;
-
+        let num_values = page_meta.num_values as usize;
+        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested[nested.nested.len() - 1].len();
         let offsets: Buffer<O> = read_buffer(reader, 1 + length, &mut scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(reader, last_offset, &mut scratch)?;

--- a/src/read/array/utf8.rs
+++ b/src/read/array/utf8.rs
@@ -146,13 +146,13 @@ where
         buffer: Vec<u8>,
     ) -> Result<(NestedState, Box<dyn Array>)> {
         let mut reader = BufReader::with_capacity(buffer.len(), Cursor::new(buffer));
-        let (nested, validity) = read_validity_nested(
+        let (mut nested, validity) = read_validity_nested(
             &mut reader,
             num_values as usize,
             &self.leaf,
             self.init.clone(),
         )?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let length = nested.nested.pop().unwrap().len();
         let offsets: Buffer<O> = read_buffer(&mut reader, 1 + length, &mut self.scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(&mut reader, last_offset, &mut self.scratch)?;
@@ -279,8 +279,8 @@ pub fn read_nested_utf8<O: Offset, R: NativeReadBuf>(
     let mut results = Vec::with_capacity(page_metas.len());
     for page_meta in page_metas {
         let num_values = page_meta.num_values as usize;
-        let (nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
-        let length = nested.nested[nested.nested.len() - 1].len();
+        let (mut nested, validity) = read_validity_nested(reader, num_values, &leaf, init.clone())?;
+        let length = nested.nested.pop().unwrap().len();
         let offsets: Buffer<O> = read_buffer(reader, 1 + length, &mut scratch)?;
         let last_offset = offsets.last().unwrap().to_usize();
         let values = read_buffer(reader, last_offset, &mut scratch)?;

--- a/src/read/batch_read.rs
+++ b/src/read/batch_read.rs
@@ -1,5 +1,4 @@
 use super::{array::*, NativeReadBuf};
-use crate::read::reader::is_primitive_or_struct;
 use crate::{with_match_primitive_type, PageMeta};
 use arrow::array::*;
 use arrow::compute::concatenate::concatenate;
@@ -119,10 +118,6 @@ pub fn read_nested<R: NativeReadBuf>(
                     read_nested(readers, inner.as_ref().clone(), leaves, init, page_metas)?;
                 let mut arrays = Vec::with_capacity(results.len());
                 for (mut nested, values) in results {
-                    if is_primitive_or_struct(&inner.data_type) {
-                        // pop the primitive nested
-                        let _ = nested.nested.pop().unwrap();
-                    }
                     let array = create_list(field.data_type().clone(), &mut nested, values);
                     arrays.push((nested, array));
                 }
@@ -134,8 +129,6 @@ pub fn read_nested<R: NativeReadBuf>(
                     read_nested(readers, inner.as_ref().clone(), leaves, init, page_metas)?;
                 let mut arrays = Vec::with_capacity(results.len());
                 for (mut nested, values) in results {
-                    // pop the primitive nested
-                    let _ = nested.nested.pop().unwrap();
                     let array = create_map(field.data_type().clone(), &mut nested, values);
                     arrays.push((nested, array));
                 }

--- a/src/read/reader.rs
+++ b/src/read/reader.rs
@@ -24,22 +24,6 @@ pub fn is_primitive(data_type: &DataType) -> bool {
     )
 }
 
-pub fn is_primitive_or_struct(data_type: &DataType) -> bool {
-    matches!(
-        data_type.to_physical_type(),
-        PhysicalType::Primitive(_)
-            | PhysicalType::Null
-            | PhysicalType::Boolean
-            | PhysicalType::Utf8
-            | PhysicalType::LargeUtf8
-            | PhysicalType::Binary
-            | PhysicalType::LargeBinary
-            | PhysicalType::FixedSizeBinary
-            | PhysicalType::Dictionary(_)
-            | PhysicalType::Struct
-    )
-}
-
 #[derive(Debug)]
 pub struct NativeReader<R: NativeReadBuf> {
     page_reader: R,

--- a/src/write/common.rs
+++ b/src/write/common.rs
@@ -11,7 +11,7 @@ use arrow::error::Result;
 use super::{write, NativeWriter};
 
 use arrow::io::parquet::write::{
-    slice_parquet_array, to_leaves, to_nested, to_parquet_leaves, SchemaDescriptor,
+    num_values, slice_parquet_array, to_leaves, to_nested, to_parquet_leaves, SchemaDescriptor,
 };
 
 /// Options declaring the behaviour of writing to IPC
@@ -65,7 +65,6 @@ impl<W: Write> NativeWriter<W> {
                         let mut sub_array = leaf_array.clone();
                         let mut sub_nested = nested.clone();
                         slice_parquet_array(sub_array.as_mut(), &mut sub_nested, offset, length);
-
                         let page_start = self.writer.offset;
                         write(
                             &mut self.writer,
@@ -79,9 +78,10 @@ impl<W: Write> NativeWriter<W> {
                         .unwrap();
 
                         let page_end = self.writer.offset;
+                        let num_values = num_values(&sub_nested);
                         PageMeta {
                             length: (page_end - page_start),
-                            num_values: sub_array.len() as u64,
+                            num_values: num_values as u64,
                         }
                     })
                     .collect();


### PR DESCRIPTION
use the `arrow2` `num_values` function to get the correct value numbers of nested columns.
